### PR TITLE
Add budget module and error controller (Issue #24)

### DIFF
--- a/Backend/budgets.controller.ts
+++ b/Backend/budgets.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Post, Patch, Delete, Param, Body } from '@nestjs/common';
+import { BudgetsService } from './budgets.service';
+
+@Controller('budgets')
+export class BudgetsController {
+  constructor(private readonly budgetsService: BudgetsService) {}
+
+  @Get()
+  getAll() {
+    return this.budgetsService.getAll();
+  }
+
+  @Get(':id')
+  getById(@Param('id') id: string) {
+    return this.budgetsService.getById(Number(id));
+  }
+
+  @Post()
+  create(@Body() body: any) {
+    return this.budgetsService.create(body);
+  }
+
+  @Patch(':BudgetID')
+update(@Param('BudgetID') id: string, @Body() body: any) {
+  return this.budgetsService.update(Number(id), body);
+}
+
+
+  @Delete(':id')
+  delete(@Param('id') id: string) {
+    return this.budgetsService.delete(Number(id));
+  }
+}

--- a/Backend/budgets.service.ts
+++ b/Backend/budgets.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+type Budget = {
+  BudgetID: number;        // Primary Key
+  TotalBudget: number;
+  ProjectID: number;       
+  ActualCost: number;
+  ForecastCost: number;
+};
+
+@Injectable()
+export class BudgetsService {
+  private budgets: Budget[] = [];
+  private nextId = 1;
+
+  getAll(): Budget[] {
+    return this.budgets;
+  }
+
+  create(data: Omit<Budget, 'BudgetID'>): Budget {
+    const newBudget: Budget = { BudgetID: this.nextId++, ...data };
+    this.budgets.push(newBudget);
+    return newBudget;
+  }
+  
+  getById(id: number): Budget {
+    const budget = this.budgets.find(b => b.BudgetID === id);
+    if (!budget) {
+      throw new NotFoundException(`Budget with ID ${id} not found`);
+    }
+    return budget;
+  }
+  
+  update(id: number, data: Partial<Omit<Budget, 'BudgetID'>>): Budget {
+    const index = this.budgets.findIndex(b => b.BudgetID === id);
+    if (index === -1) {
+      throw new NotFoundException(`Budget with ID ${id} not found`);
+    }
+    this.budgets[index] = { ...this.budgets[index], ...data };
+    return this.budgets[index];
+  }
+  
+  delete(id: number): Budget {
+    const index = this.budgets.findIndex(b => b.BudgetID === id);
+    if (index === -1) {
+      throw new NotFoundException(`Budget with ID ${id} not found`);
+    }
+    return this.budgets.splice(index, 1)[0];
+  }
+}

--- a/Backend/error.controller.ts
+++ b/Backend/error.controller.ts
@@ -1,0 +1,16 @@
+
+import { Controller, Get, HttpException, HttpStatus } from '@nestjs/common';
+//new controller that listens to requests at the '/error' route
+@Controller('error')
+export class ErrorController {
+  // Handle GET /error and simulate a server-side failure
+  @Get()
+  triggerError() {
+    
+    throw new HttpException({
+      status: HttpStatus.INTERNAL_SERVER_ERROR, 
+      error: 'Global error test',                
+      message: 'This is a simulated global error from the error module.' 
+    }, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+}


### PR DESCRIPTION
This PR adds:
- A fully working budget module with CRUD endpoints (GET, POST, PATCH, DELETE)
- A separate error.controller.ts for simulating internal server errors

Closes #24